### PR TITLE
feat(api): map provider errors via apiErrorType passthrough in genera…

### DIFF
--- a/src/pages/api/ai-image/generate.ts
+++ b/src/pages/api/ai-image/generate.ts
@@ -96,6 +96,20 @@ export const POST = withApiMiddleware(async (context) => {
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unbekannter Fehler';
+    // Prefer typed errors coming from services (e.g., provider mapping)
+    const typed = (err as any)?.apiErrorType as
+      | 'validation_error'
+      | 'auth_error'
+      | 'not_found'
+      | 'rate_limit'
+      | 'server_error'
+      | 'db_error'
+      | 'forbidden'
+      | 'method_not_allowed'
+      | undefined;
+    if (typed) {
+      return createApiError(typed, message);
+    }
     if (typeof (err as any)?.code === 'string' && (err as any).code === 'quota_exceeded') {
       return createApiError('forbidden', 'Kostenloses Nutzungslimit erreicht', (err as any).details || undefined);
     }

--- a/tests/unit/ai-image-provider-mapping.test.ts
+++ b/tests/unit/ai-image-provider-mapping.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AiImageService } from '@/lib/services/ai-image-service';
+import type { AllowedModel } from '@/config/ai-image';
+
+const DUMMY_MODEL: AllowedModel = {
+  slug: 'owner/model:tag',
+  label: 'Dummy',
+  provider: 'replicate',
+  supportsScale: false,
+  supportsFaceEnhance: false,
+};
+
+function makeService(env: Partial<{ REPLICATE_API_TOKEN: string; ENVIRONMENT: string }>) {
+  // Only fields used by runReplicate are needed
+  return new AiImageService({
+    REPLICATE_API_TOKEN: env.REPLICATE_API_TOKEN ?? 'token',
+    ENVIRONMENT: env.ENVIRONMENT ?? 'production',
+  } as any);
+}
+
+async function withMockedFetch<T>(status: number, body: string = 'err', fn: () => Promise<T>) {
+  const original = globalThis.fetch;
+  const res = new Response(body, { status });
+  // @ts-expect-error allow vi mock assignment
+  globalThis.fetch = vi.fn(async () => res);
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+describe('AiImageService.runReplicate() provider error mapping', () => {
+  let service: AiImageService;
+  beforeEach(() => {
+    service = makeService({ REPLICATE_API_TOKEN: 't', ENVIRONMENT: 'production' });
+  });
+
+  it('maps 401 to forbidden', async () => {
+    await withMockedFetch(401, 'unauthorized', async () => {
+      await expect(((service as any).runReplicate)(DUMMY_MODEL, { image: 'http://x' }))
+        .rejects.toMatchObject({ apiErrorType: 'forbidden', status: 401 });
+    });
+  });
+
+  it('maps 403 to forbidden', async () => {
+    await withMockedFetch(403, 'forbidden', async () => {
+      await expect(((service as any).runReplicate)(DUMMY_MODEL, { image: 'http://x' }))
+        .rejects.toMatchObject({ apiErrorType: 'forbidden', status: 403 });
+    });
+  });
+
+  it('maps 404 to validation_error', async () => {
+    await withMockedFetch(404, 'not found', async () => {
+      await expect(((service as any).runReplicate)(DUMMY_MODEL, { image: 'http://x' }))
+        .rejects.toMatchObject({ apiErrorType: 'validation_error', status: 404 });
+    });
+  });
+
+  it('maps 422 to validation_error', async () => {
+    await withMockedFetch(422, 'unprocessable', async () => {
+      await expect(((service as any).runReplicate)(DUMMY_MODEL, { image: 'http://x' }))
+        .rejects.toMatchObject({ apiErrorType: 'validation_error', status: 422 });
+    });
+  });
+
+  it('maps 500 to server_error', async () => {
+    await withMockedFetch(500, 'server err', async () => {
+      await expect(((service as any).runReplicate)(DUMMY_MODEL, { image: 'http://x' }))
+        .rejects.toMatchObject({ apiErrorType: 'server_error', status: 500 });
+    });
+  });
+});


### PR DESCRIPTION
…te route; test(unit): verify runReplicate mapping 401/403→forbidden, 4xx→validation_error, 5xx→server_error