### PR TITLE
feat(uiux): quick wins on FAQ, Contact, Docs, Blog index

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -100,7 +100,7 @@ baseUrlForPagination.searchParams.delete('page');
           {title}
         </h1>
         <p
-          class="mt-2 text-lg leading-8 text-gray-600 dark:text-gray-300"
+          class="mt-2 text-lg leading-8 text-gray-700 dark:text-gray-300"
           data-aos="fade-up"
           data-aos-delay="100"
           data-aos-duration="650"
@@ -204,7 +204,7 @@ baseUrlForPagination.searchParams.delete('page');
                 </p>
                 <a
                   href="/blog/"
-                  class="text-sm font-medium text-emerald-700 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
+                  class="text-sm font-medium text-emerald-700 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 rounded"
                 >
                   Filter zurücksetzen
                 </a>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -38,7 +38,7 @@ const sections = [
         <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-4xl">
           Alles was Sie wissen müssen
         </p>
-        <p class="mt-4 max-w-2xl text-xl text-gray-500 dark:text-gray-300 lg:mx-auto">
+        <p class="mt-4 max-w-2xl text-xl text-gray-700 dark:text-gray-300 lg:mx-auto">
           Umfassende Anleitungen und Dokumentationen, die Ihnen helfen, das Beste aus Evolution Hub herauszuholen.
         </p>
       </div>
@@ -50,7 +50,7 @@ const sections = [
               href={section.link}
               data-aos="fade-up"
               data-aos-delay={String(aosDelayForIndex(idx, { step: 100, max: 300 }))}
-              class="group relative bg-white dark:bg-gray-800 p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500 rounded-lg border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow duration-200"
+              class="group relative bg-white dark:bg-gray-800 p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none rounded-lg border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow duration-200"
             >
               <div>
                 <span class="rounded-lg inline-flex p-3 bg-indigo-50 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-200 ring-4 ring-white dark:ring-gray-800">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -43,13 +43,13 @@ const faqCategories = orderedIds.map((id) => ({
 
 <BaseLayout title={t('faq.title')}>
   <!-- Hero Section -->
-  <section class="py-16 md:py-24 bg-gradient-to-br from-primary/5 to-purple-500/5 dark:from-gray-800 dark:to-gray-900">
+  <section class="py-16 md:py-24 allow-section-bg bg-gradient-to-br from-primary/5 to-purple-500/5 dark:from-gray-800 dark:to-gray-900">
     <div class="container mx-auto px-4">
       <div class="max-w-4xl mx-auto text-center">
-        <h1 class="text-4xl md:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
+        <h1 class="text-4xl md:text-5xl font-bold mb-6 text-gray-900 dark:text-white [text-shadow:_0_1px_0_rgb(255_255_255_/_0.6)] dark:[text-shadow:_0_1px_0_rgb(0_0_0_/_0.35)]">
           {t('faq.hero.heading')}
         </h1>
-        <p class="text-xl text-gray-600 dark:text-gray-300">
+        <p class="text-xl text-gray-700 dark:text-gray-300">
           {t('faq.hero.subtitle')}
         </p>
 
@@ -76,7 +76,7 @@ const faqCategories = orderedIds.map((id) => ({
         <!-- Kategorien-Navigation -->
         <div class="flex flex-wrap gap-3 mb-10 justify-center" id="faq-categories">
           <button
-            class="px-4 py-2 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400 font-medium text-sm transition-colors duration-200"
+            class="px-4 py-2 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400 font-medium text-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none"
             data-category="all"
           >
             {t('faq.categories.all')}
@@ -84,7 +84,7 @@ const faqCategories = orderedIds.map((id) => ({
           {faqCategories.map(category => (
             <div>
               <button
-                class="px-4 py-2 rounded-full bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 font-medium text-sm hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200 flex items-center gap-2"
+                class="px-4 py-2 rounded-full bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 font-medium text-sm hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200 flex items-center gap-2 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 data-category={category.id}
               >
                 <span class="w-5 h-5 flex items-center justify-center" set:html={categoryIcons[category.id] || categoryIcons.allgemein}></span>
@@ -109,7 +109,7 @@ const faqCategories = orderedIds.map((id) => ({
                   return (
                     <div class="faq-item bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden transition-all duration-200 hover:shadow-md dark:hover:shadow-lg dark:hover:shadow-gray-900/10">
                       <button
-                        class="w-full px-6 py-5 text-left flex items-center justify-between focus:outline-none group hover:bg-gray-50/80 dark:hover:bg-gray-700/80 transition-colors duration-200"
+                        class="w-full px-6 py-5 text-left flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 group hover:bg-gray-50/80 dark:hover:bg-gray-700/80 transition-colors duration-200"
                         aria-expanded="false"
                         aria-controls={itemId}
                         id={`${itemId}-button`}
@@ -148,7 +148,7 @@ const faqCategories = orderedIds.map((id) => ({
   </section>
 
   <!-- Contact Section -->
-  <section class="py-16 bg-gradient-to-br from-emerald-100 to-cyan-100 dark:from-gray-800 dark:to-gray-900">
+  <section class="py-16 allow-section-bg bg-gradient-to-br from-emerald-100 to-cyan-100 dark:from-gray-800 dark:to-gray-900">
     <div class="container mx-auto px-4">
       <div class="max-w-4xl mx-auto bg-white dark:bg-gray-800 rounded-2xl shadow-lg overflow-hidden">
         <div class="grid md:grid-cols-2">

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -22,13 +22,13 @@ const heroSubtitle = hasText(tx('pages.kontakt.hero.subtitle'))
 
 <BaseLayout title={pageTitle}>
   <!-- Hero Section -->
-  <section class="py-16 md:py-24 bg-gradient-to-br from-primary/5 to-purple-500/5 dark:from-gray-800 dark:to-gray-900">
+  <section class="py-16 md:py-24 allow-section-bg bg-gradient-to-br from-primary/5 to-purple-500/5 dark:from-gray-800 dark:to-gray-900">
     <div class="container mx-auto px-4">
       <div class="max-w-3xl mx-auto text-center">
-        <h1 class="text-4xl md:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
+        <h1 class="text-4xl md:text-5xl font-bold mb-6 text-gray-900 dark:text-white [text-shadow:_0_1px_0_rgb(255_255_255_/_0.6)] dark:[text-shadow:_0_1px_0_rgb(0_0_0_/_0.35)]">
           {heroHeading}
         </h1>
-        <p class="text-xl text-gray-600 dark:text-gray-300 mb-8">
+        <p class="text-xl text-gray-700 dark:text-gray-300 mb-8">
           {heroSubtitle}
         </p>
       </div>
@@ -130,7 +130,7 @@ const heroSubtitle = hasText(tx('pages.kontakt.hero.subtitle'))
             </div>
 
             <!-- Contact Info -->
-            <div class="bg-gradient-to-br from-emerald-50 to-cyan-50 dark:from-gray-800 dark:to-gray-900 p-8 md:p-10 flex flex-col justify-center">
+            <div class="allow-section-bg bg-gradient-to-br from-emerald-50 to-cyan-50 dark:from-gray-800 dark:to-gray-900 p-8 md:p-10 flex flex-col justify-center">
               <div class="space-y-6">
                 <div>
                   <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{hasText(tx('pages.kontakt.info.heading')) ? tx('pages.kontakt.info.heading') : (locale === 'en' ? 'Contact information' : 'Kontaktinformationen')}</h3>


### PR DESCRIPTION
Summary
- Apply the same UI/UX improvements as Index: better hero contrast, higher paragraph contrast, focus-visible rings, preserve section backgrounds via allow-section-bg.

Files
- src/pages/faq.astro
- src/pages/kontakt.astro
- src/pages/docs/index.astro
- src/pages/blog/index.astro

QA Checklist
- [ ] FAQ: hero headline legible, category chips get focus rings, accordion triggers have focus-visible rings
- [ ] Contact: hero headline legible, right gradient panel preserved, inputs keep accessible focus
- [ ] Docs index: section cards have keyboard focus rings, paragraph contrast improved
- [ ] Blog index: heading paragraph contrast improved, tag chips and reset link have focus-visible rings

Build/Tests
- [x] npm run build:worker OK

Notes
- Excluded pages that use Coming Soon overlay (e.g. Tools index).
- Changes are locale-aware because EN routes re-export the same base pages.