### PR TITLE
feat(uiux): focus-visible rings on pricing & Imag-Enhancer CTAs

### DIFF
--- a/src/components/pricing/PricingTable.astro
+++ b/src/components/pricing/PricingTable.astro
@@ -97,7 +97,7 @@ const plans: Plan[] = [
           plan.featured
             ? 'bg-blue-600 text-white hover:bg-blue-700'
             : 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600'
-        } transition-colors`}
+        } transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2`}
       >
         {plan.cta}
       </a>

--- a/src/pages/en/tools/imag-enhancer/app.astro
+++ b/src/pages/en/tools/imag-enhancer/app.astro
@@ -60,7 +60,7 @@ const tool = {
             {t('pages.tools.items.Imag-Enhancer.name')}
           </h1>
           <div class="mt-2">
-            <a href={localizePath(locale, '/tools/imag-enhancer')} class="text-sm text-gray-500 dark:text-gray-400 hover:underline">
+            <a href={localizePath(locale, '/tools/imag-enhancer')} class="text-sm text-gray-500 dark:text-gray-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 rounded">
               {t('pages.tools.details.Imag-Enhancer.back')}
             </a>
           </div>

--- a/src/pages/en/tools/imag-enhancer/index.astro
+++ b/src/pages/en/tools/imag-enhancer/index.astro
@@ -42,10 +42,10 @@ const tool = {
           <p class="mt-4 text-gray-600 dark:text-gray-300">{t('pages.tools.details.Imag-Enhancer.longDescription')}</p>
 
           <div class="mt-6 flex flex-wrap gap-3">
-            <a href={localizePath(locale, tool.url)} class="inline-flex items-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-gradient-to-r from-[#00d4aa] to-[#40e0d0] hover:opacity-90 transition">
+            <a href={localizePath(locale, tool.url)} class="inline-flex items-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-gradient-to-r from-[#00d4aa] to-[#40e0d0] hover:opacity-90 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2">
               {t('pages.tools.details.Imag-Enhancer.open')}
             </a>
-            <a href={localizePath(locale, '/kontakt')} class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700">
+            <a href={localizePath(locale, '/kontakt')} class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2">
               {t('pages.tools.details.Imag-Enhancer.support')}
             </a>
           </div>
@@ -101,7 +101,7 @@ const tool = {
       </section>
 
       <div class="mt-10 text-center">
-        <a href={localizePath(locale, tool.url)} class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition">
+        <a href={localizePath(locale, tool.url)} class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2">
           {t('pages.tools.details.Imag-Enhancer.try')}
         </a>
       </div>


### PR DESCRIPTION
Accessibility improvement:
- PricingTable CTAs now show focus-visible rings.
- Imag-Enhancer (index/app) primary links/buttons have focus-visible rings.

Build OK via npm run build:worker.