### PR TITLE
feat(auth,e2e,ci): first-login interstitial + prod auth smoke

### DIFF
--- a/.github/workflows/prod-auth-smoke.yml
+++ b/.github/workflows/prod-auth-smoke.yml
@@ -1,0 +1,57 @@
+name: Prod Auth Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      run:
+        description: "Run prod auth smoke against hub-evolution.com"
+        required: false
+        default: "false"
+  schedule:
+    - cron: '0 4 * * *'  # optional daily run at 04:00 UTC
+
+jobs:
+  prod-auth-smoke:
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.run == 'true' }}
+    name: Prod Auth Smoke (hub-evolution.com)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Gate the test strictly behind env switches and secrets
+      TEST_BASE_URL: https://hub-evolution.com
+      E2E_PROD_AUTH_SMOKE: ${{ secrets.E2E_PROD_AUTH_SMOKE }}
+      STYTCH_TEST_EMAIL: ${{ secrets.STYTCH_TEST_EMAIL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install --with-deps
+
+      - name: Run Prod Auth Smoke (hub-evolution.com)
+        run: |
+          if [ "${E2E_PROD_AUTH_SMOKE}" != "1" ] && [ "${E2E_PROD_AUTH_SMOKE}" != "true" ]; then
+            echo "E2E_PROD_AUTH_SMOKE is not enabled; skipping." && exit 0
+          fi
+          if [ -z "${STYTCH_TEST_EMAIL}" ]; then
+            echo "STYTCH_TEST_EMAIL is not set; skipping." && exit 0
+          fi
+          npx playwright test test-suite-v2/src/e2e/prod-auth-smoke.spec.ts --reporter=list
+
+      - name: Upload Playwright results (if any)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-auth-smoke-results
+          path: test-suite-v2/reports/**
+          if-no-files-found: ignore

--- a/docs/api/auth_api.md
+++ b/docs/api/auth_api.md
@@ -29,11 +29,23 @@ Hinweis: Die frühere Login-Variante `login-v2` wurde entfernt. Verwende ausschl
   * `magic/request` antwortet JSON (kein Redirect)
   * `callback` antwortet mit direktem Redirect zum Ziel (ggf. lokalisiert)
 
+### Production‑Hinweise (Stytch Live)
+
+* Redirect‑URLs in Stytch (Live) whitelisten:
+  * `https://hub-evolution.com/api/auth/callback`
+  * optional zusätzlich: `https://www.hub-evolution.com/api/auth/callback`
+* Erforderliche Secrets/Variablen (Wrangler, `--env production`):
+  * `STYTCH_PROJECT_ID` (Live, beginnt mit `project-live-…`)
+  * `STYTCH_SECRET`
+  * `AUTH_PROVIDER=stytch`
+* CSRF/Origin: `POST /api/auth/magic/request` verlangt same‑origin `Origin`/`Referer`.
+  * curl‑Beispiel: `-H 'Origin: https://hub-evolution.com'`
+
 ---
 
 > Hinweis: Alle legacy Passwort-basierten Endpunkte (login/register/forgot/reset) wurden entfernt. Das System verwendet ausschließlich Stytch Magic Link (`/api/auth/magic/request` → `/api/auth/callback`).
 
-## 5. Logout
+### 5. Logout
 
 Beendet die aktuelle Benutzersitzung und löscht das Session-Cookie.
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -559,6 +559,20 @@
         "cooldown": "Erneut senden in {s}s"
       }
     },
+    "welcomeProfile": {
+      "title": "Profil vervollständigen",
+      "description": "Name und Benutzername festlegen",
+      "heading": "Willkommen! Profil vervollständigen",
+      "helper": "Wir haben dein Konto erstellt. Du kannst jetzt deinen öffentlichen Namen und Benutzernamen festlegen oder dies später in den Einstellungen erledigen.",
+      "fields": {
+        "name": { "label": "Name" },
+        "username": { "label": "Benutzername" }
+      },
+      "buttons": {
+        "saveContinue": "Speichern und weiter",
+        "skipNow": "Später"
+      }
+    },
     "forgotPassword": {
       "title": "Passwort vergessen",
       "form": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -761,6 +761,20 @@
         "cooldown": "Erneut senden in {s}s"
       }
     },
+    "welcomeProfile": {
+      "title": "Complete your profile",
+      "description": "Set your name and username",
+      "heading": "Welcome! Complete your profile",
+      "helper": "We created your account. You can adjust your public name and username now or do it later in settings.",
+      "fields": {
+        "name": { "label": "Name" },
+        "username": { "label": "Username" }
+      },
+      "buttons": {
+        "saveContinue": "Save and continue",
+        "skipNow": "Skip for now"
+      }
+    },
     "forgotPassword": {
       "title": "Passwort vergessen",
       "form": {

--- a/src/pages/welcome-profile.astro
+++ b/src/pages/welcome-profile.astro
@@ -1,0 +1,44 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import FormLabel from '@/components/ui/FormLabel.astro';
+import Input from '@/components/ui/Input.astro';
+import Button from '@/components/ui/Button.astro';
+import type { Locale } from '@/lib/i18n';
+import { getLocale } from '@/lib/i18n';
+import { getI18n } from '@/utils/i18n';
+
+// Require auth via middleware; page assumes a valid session cookie
+const nextRaw = Astro.url.searchParams.get('next') || '/dashboard';
+
+function isAllowedRelativePath(p: string): boolean {
+  return typeof p === 'string' && p.startsWith('/') && !p.startsWith('//');
+}
+
+const nextSafe = isAllowedRelativePath(nextRaw) ? nextRaw : '/dashboard';
+const locale: Locale = getLocale(Astro.url.pathname);
+const t = getI18n(locale);
+---
+<BaseLayout title={t('pages.welcomeProfile.title') ?? 'Complete your profile'} description={t('pages.welcomeProfile.description') ?? 'Set your name and username'} noIndex={true}>
+  <section class="mx-auto max-w-md px-4 py-12">
+    <h1 class="text-xl font-semibold tracking-tight">{t('pages.welcomeProfile.heading') ?? 'Welcome! Complete your profile'}</h1>
+    <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+      {t('pages.welcomeProfile.helper') ?? 'We created your account. You can adjust your public name and username now or do it later in settings.'}
+    </p>
+
+    <form method="POST" action="/api/user/profile" class="mt-6 space-y-4">
+      <div>
+        <FormLabel for="name">{t('pages.welcomeProfile.fields.name.label') ?? 'Name'}</FormLabel>
+        <Input id="name" name="name" type="text" minlength="2" maxlength="50" autocomplete="name" required />
+      </div>
+      <div>
+        <FormLabel for="username">{t('pages.welcomeProfile.fields.username.label') ?? 'Username'}</FormLabel>
+        <Input id="username" name="username" type="text" minlength="3" maxlength="30" pattern="[a-zA-Z0-9_]+" autocomplete="username" required />
+      </div>
+      <input type="hidden" name="next" value={nextSafe} />
+      <div class="flex items-center gap-3 pt-2">
+        <Button type="submit">{t('pages.welcomeProfile.buttons.saveContinue') ?? 'Save and continue'}</Button>
+        <a href={nextSafe} class="text-sm text-zinc-500 hover:text-zinc-300 underline underline-offset-4">{t('pages.welcomeProfile.buttons.skipNow') ?? 'Skip for now'}</a>
+      </div>
+    </form>
+  </section>
+</BaseLayout>

--- a/test-suite-v2/src/e2e/auth-first-login-profile.spec.ts
+++ b/test-suite-v2/src/e2e/auth-first-login-profile.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+// This test runs only on local/dev (E2E_FAKE_STYTCH=1). It simulates a first-time
+// login via Magic Link callback, asserts redirect to /welcome-profile, completes
+// the profile form, and verifies redirect to the dashboard.
+
+const BASE = process.env.TEST_BASE_URL || process.env.BASE_URL || 'http://127.0.0.1:8787';
+
+function isRemote(urlStr: string): boolean {
+  try {
+    const u = new URL(urlStr);
+    return !(u.hostname === 'localhost' || u.hostname === '127.0.0.1');
+  } catch {
+    return false;
+  }
+}
+
+const REMOTE = isRemote(BASE);
+
+// Generate a unique email for each run to exercise the first-login path
+function uniqueEmail(): string {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `first-${rand}@example.com`;
+}
+
+test.describe('First login → welcome-profile interstitial', () => {
+  test.skip(REMOTE, 'Runs only on local dev (uses E2E_FAKE_STYTCH)');
+
+  test('redirects new user to /welcome-profile, saves profile, then goes to dashboard', async ({ browser }) => {
+    const email = uniqueEmail();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Hit the callback using the e2e:email token to control fake identity
+    const url = new URL('/api/auth/callback', BASE);
+    url.searchParams.set('token', `e2e:${email}`);
+
+    await page.goto(url.toString(), { waitUntil: 'domcontentloaded' });
+
+    // Expect interstitial
+    await expect(page).toHaveURL(new RegExp('/welcome-profile')); // allows query params
+
+    // Fill minimal profile
+    await page.fill('#name', 'E2E User');
+    await page.fill('#username', `e2e_${Date.now().toString().slice(-6)}`);
+    await page.click('button[type="submit"]');
+
+    // After POST, API redirects (303) to next target → default /dashboard
+    await page.waitForLoadState('domcontentloaded');
+
+    const loc = new URL(page.url());
+    expect(['/dashboard', '/en/dashboard', '/de/dashboard']).toContain(loc.pathname);
+
+    // Session cookies should exist
+    const cookies = await context.cookies(BASE);
+    expect(cookies.find(c => c.name === '__Host-session')).toBeTruthy();
+
+    await context.close();
+  });
+});

--- a/test-suite-v2/src/e2e/prod-auth-smoke.spec.ts
+++ b/test-suite-v2/src/e2e/prod-auth-smoke.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+// Production auth smoke tests for hub-evolution.com
+// Safe checks only: we verify that Magic Link request succeeds (200 JSON)
+// and that callback without token redirects back to login with an error.
+//
+// To enable, set:
+//   E2E_PROD_AUTH_SMOKE=1
+//   TEST_BASE_URL=https://hub-evolution.com
+//   STYTCH_TEST_EMAIL=<your test email>
+// Otherwise this spec will be skipped.
+
+const BASE = process.env.TEST_BASE_URL || '';
+const ENABLED = process.env.E2E_PROD_AUTH_SMOKE === '1' || process.env.E2E_PROD_AUTH_SMOKE === 'true';
+const EMAIL = process.env.STYTCH_TEST_EMAIL || '';
+
+function isHubProd(urlStr: string): boolean {
+  try {
+    const u = new URL(urlStr);
+    return u.origin === 'https://hub-evolution.com';
+  } catch {
+    return false;
+  }
+}
+
+test.describe('Prod Auth Smoke (hub-evolution.com)', () => {
+  test.skip(!(ENABLED && isHubProd(BASE) && EMAIL), 'Set E2E_PROD_AUTH_SMOKE=1, TEST_BASE_URL=https://hub-evolution.com and STYTCH_TEST_EMAIL to run');
+
+  test('POST /api/auth/magic/request returns 200 { sent: true }', async ({ request }) => {
+    const res = await request.post(new URL('/api/auth/magic/request', BASE).toString(), {
+      headers: {
+        'Origin': 'https://hub-evolution.com',
+        'Content-Type': 'application/json'
+      },
+      data: {
+        email: EMAIL,
+        r: '/dashboard',
+        locale: 'en'
+      }
+    });
+
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ success: true, data: { sent: true } });
+  });
+
+  test('GET /login returns security headers (CSP, HSTS, X-Frame-Options, COOP)', async ({ request }) => {
+    // English or neutral route should both set headers via middleware
+    const res = await request.get(new URL('/en/login', BASE).toString(), { maxRedirects: 0 });
+    expect([200, 302, 301, 303]).toContain(res.status());
+    const headers = res.headers();
+    // Core headers we expect in production
+    expect(typeof headers['content-security-policy'] === 'string' || typeof headers['Content-Security-Policy'] === 'string').toBeTruthy();
+    expect((headers['strict-transport-security'] || headers['Strict-Transport-Security'])?.includes('max-age')).toBeTruthy();
+    expect((headers['x-frame-options'] || headers['X-Frame-Options'])?.toUpperCase()).toContain('DENY');
+    expect((headers['cross-origin-opener-policy'] || headers['Cross-Origin-Opener-Policy'])?.toLowerCase()).toBe('same-origin');
+  });
+
+  test('GET /api/auth/callback without token redirects to login error', async ({ request }) => {
+    const res = await request.get(new URL('/api/auth/callback', BASE).toString(), { maxRedirects: 0 });
+    expect([302, 301, 303]).toContain(res.status());
+    const loc = res.headers()['location'] || res.headers()['Location'];
+    expect(typeof loc).toBe('string');
+    const location = String(loc);
+    expect(location.includes('/en/login?magic_error=MissingToken') || location.includes('/login?magic_error=MissingToken')).toBeTruthy();
+    // Redirect responses should also carry security headers
+    const headers = res.headers();
+    expect(typeof headers['content-security-policy'] === 'string' || typeof headers['Content-Security-Policy'] === 'string').toBeTruthy();
+    expect((headers['strict-transport-security'] || headers['Strict-Transport-Security'])?.includes('max-age')).toBeTruthy();
+    expect((headers['x-frame-options'] || headers['X-Frame-Options'])?.toUpperCase()).toContain('DENY');
+    expect((headers['cross-origin-opener-policy'] || headers['Cross-Origin-Opener-Policy'])?.toLowerCase()).toBe('same-origin');
+  });
+
+  test('GET /api/auth/callback with invalid token redirects to login InvalidOrExpired', async ({ request }) => {
+    const url = new URL('/api/auth/callback', BASE);
+    url.searchParams.set('token', 'definitely-invalid-token');
+    const res = await request.get(url.toString(), { maxRedirects: 0 });
+    expect([302, 301, 303]).toContain(res.status());
+    const loc = res.headers()['location'] || res.headers()['Location'];
+    expect(typeof loc).toBe('string');
+    const location = String(loc);
+    expect(location.includes('/en/login?magic_error=InvalidOrExpired') || location.includes('/login?magic_error=InvalidOrExpired')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This PR introduces:\n\n- First-login interstitial: redirect new users to /welcome-profile after Magic Link callback when no name/username were provided.\n- Localized welcome-profile page (DE/EN) with i18n keys under pages.welcomeProfile.*.\n- Profile API now supports 303 redirect to 'next' after POST.\n- Local E2E: first-login interstitial spec using E2E_FAKE_STYTCH and token pattern e2e:<email>.\n- Prod E2E smoke: validates /api/auth/magic/request (200 JSON), callback missing/invalid token redirects with magic_error, and security headers (CSP, HSTS, X-Frame-Options, COOP).\n- CI workflow: .github/workflows/prod-auth-smoke.yml gated by secrets (E2E_PROD_AUTH_SMOKE, STYTCH_TEST_EMAIL).\n\nAfter merge:\n- Trigger via Actions → Prod Auth Smoke → Run workflow (set run=true).\n- Or via CLI: gh workflow run prod-auth-smoke.yml -f run=true.\n\nNotes:\n- Ensure Stytch Live Redirect URL: https://hub-evolution.com/api/auth/callback is whitelisted.\n- Secrets set: E2E_PROD_AUTH_SMOKE=1, STYTCH_TEST_EMAIL per your actions above.