### PR TITLE
docs: add Windsurf cascade ruleset

### DIFF
--- a/.windsurf/global_rules.md
+++ b/.windsurf/global_rules.md
@@ -1,0 +1,43 @@
+# Evolution Hub — Verified Repo Rules
+
+## Stack & Deployment
+- Astro 5 with Cloudflare directory adapter drives the worker build; static asset headers are declared in `astro.config.mjs` for cache control and CSP coverage during dev.
+- Cloudflare Workers rely on D1, multiple R2 buckets, and KV namespaces defined in `wrangler.toml`; environment-specific secrets and bindings (e.g., `DB`, `R2_AI_IMAGES`, `SITE_PASSWORD`) come from Wrangler envs.
+- Build output targets server mode with Worker entry `dist/_worker.js/index.js`; Wrangler serves static assets from `dist` with `.assetsignore` to skip `_worker.js`.
+
+## Repository Layout
+- Runtime source is under `src/` with UI components/layouts in `src/components` and `src/layouts`, API routes in `src/pages/api`, shared logic in `src/lib`, config in `src/config`, and middleware in `src/middleware.ts` (`AGENTS.md`).
+- Tests span Vitest projects in `tests/unit` and `tests/integration`, legacy fixtures under `tests/src`, and Playwright specs in `tests/e2e` plus the newer suite in `test-suite-v2/` (`AGENTS.md`, `vitest.config.ts`).
+- Content resources live in `src/content` and `src/locales`; scripts and migrations stay in `scripts/` and `migrations/` (`AGENTS.md`).
+
+## Tooling & Conventions
+- TypeScript enforces `strict`, `noUnusedLocals`, and `noUnusedParameters` with path aliases like `@/*` defined in `tsconfig.json`.
+- ESLint (config in `eslint.config.js`) applies TypeScript + React hooks rules, warns on `any`, ignores `_`-prefixed unuseds, forbids `~/*` imports, and enforces `no-console` only on the migrated API files listed there.
+- Prettier (`.prettierrc.json`) uses 2 spaces, single quotes, 100 character width, and Astro plugin overrides.
+- File naming keeps components/stores PascalCase and shared utilities camelCase as reiterated in `AGENTS.md`.
+
+## Commands & Automation
+- Worker-oriented dev uses `npm run dev:worker`/`dev:worker:dev`, with `dev:e2e` bootstrapping Wrangler after database setup; Astro-only dev still available via `npm run dev:astro` (`package.json`).
+- Build and preview via `npm run build` and `npm run preview`; worker bundling script `build:worker` copies assets into `dist/assets` and writes `.assetsignore` (`package.json`).
+- Testing commands include `npm run test` (Vitest multi-project), scoped `test:unit`, `test:integration`, coverage reporting `test:coverage`, and Playwright targets such as `test:e2e` and browser-specific variants (`package.json`, `vitest.config.ts`, `playwright.config.ts`).
+- Formatting and linting rely on `npm run format`, `format:check`, `lint`, plus markdown linters and documentation generators captured in `package.json`.
+
+## Testing Gates & Configuration
+- Vitest defaults to globals, disables watch, and enforces V8 coverage thresholds at 70% for statements/branches/functions/lines with `include: src/**/*.{ts,tsx}`; unit tests run in `jsdom` with `src/setupTests.ts`, integration tests run in Node with a global setup (`vitest.config.ts`).
+- Playwright config auto-starts `npm run dev:e2e` for local targets, injects same-origin `Origin` header on POSTs, retries twice on CI, and stores HTML reports in `playwright-report` (`playwright.config.ts`).
+
+## Security & Middleware Expectations
+- Global middleware (`src/middleware.ts`) logs each request with requestId, canonicalizes `www` traffic to apex, enforces optional Basic Auth on production HTML (excluding `/api/**`, assets, `/r2-ai/**`), generates per-request CSP nonces, handles locale redirects, and exposes IP anonymization with header redaction.
+- Middleware also recognizes `SITE_AUTH_ENABLED` and `SITE_PASSWORD`, checks session cookies (`__Host-session`, `session_id`), and keeps `/r2-ai/**` outside gates.
+- API middleware (`src/lib/api-middleware.ts`) standardizes JSON shapes via `createApiSuccess`/`createApiError`, applies security headers (HSTS with preload, X-Frame-Options DENY, etc.), enforces same-origin checks on unsafe methods by default, offers optional double submit CSRF enforcement, and integrates rate limiters (default 30/minute `apiRateLimiter`).
+- Rate limiter presets in `src/lib/rate-limiter.ts` expose named guards (`standardApiLimiter`, `authLimiter`, `sensitiveActionLimiter`, `aiGenerateLimiter`, `aiJobsLimiter`), all emitting `Retry-After` on 429.
+- Client/server CSRF helpers live in `src/lib/security/csrf.ts`, issuing 32-hex tokens with Lax cookies and necessitating header/cookie matches during validation.
+
+## Feature Flags & Content Controls
+- Coming Soon overlay logic in `src/config/coming-soon.ts` keeps `/datenschutz*` off-limits, honors ENV override `COMING_SOON`, strips locale prefixes, and treats `/docs`, `/kontakt`, `/agb`, `/impressum` as default overlays.
+- CSP defaults for prerendered HTML in dev are set through `DEV_CSP` inside `astro.config.mjs`; runtime CSP enforcement is centralized in middleware.
+
+## Observability & Debugging
+- Logging utilities (`src/server/utils/logger`, `logger-factory`) feed middleware tracing and API security logs; client batching to `/api/debug/client-log` is gated by feature flag `PUBLIC_ENABLE_DEBUG_PANEL` referenced in `AGENTS.md` and `src/lib/client-logger.ts`.
+- Wrangler config enables optional `logpush`, keeps `[observability.logs]` disabled by default, and exposes tailing scripts (`package.json` – `tail:staging`, `tail:prod`).
+

--- a/.windsurf/rules/api-and-security.md
+++ b/.windsurf/rules/api-and-security.md
@@ -1,0 +1,9 @@
+# API & Security Rules
+
+- Wrap Astro API handlers with `withApiMiddleware`/`withAuthApiMiddleware` from `src/lib/api-middleware.ts` to inherit security headers, logging, and default `apiRateLimiter` (30 req/min) unless a different preset from `src/lib/rate-limiter.ts` is required.
+- Return JSON via `createApiSuccess({ data })` for success and `createApiError({ type, message, details? })` for errors to keep response shapes consistent (`src/lib/api-middleware.ts`).
+- Always supply 405 responses through `createMethodNotAllowed` so the `Allow` header is set (`src/lib/api-middleware.ts`).
+- Unsafe methods (POST/PUT/PATCH/DELETE) must satisfy same-origin checks; enable double-submit validation by passing `enforceCsrfToken: true` when endpoints rely on the `csrf_token` cookie (`src/lib/api-middleware.ts`, `src/lib/security/csrf.ts`).
+- Respect Basic Auth gating logic in `src/middleware.ts`: never gate `/api/**`, Static assets, or `/r2-ai/**`, and only require credentials when `SITE_AUTH_ENABLED` and `SITE_PASSWORD` are configured for production hosts.
+- Keep `/r2-ai/**` routes publicly accessible and exempt from overlays or auth, per middleware safeguards (`src/middleware.ts`).
+- Preserve security headers established by middleware and API helpers (HSTS preload, X-Frame-Options DENY, Permissions-Policy camera/microphone/geolocation empty) (`src/lib/api-middleware.ts`).

--- a/.windsurf/rules/project-structure.md
+++ b/.windsurf/rules/project-structure.md
@@ -1,0 +1,8 @@
+# Project Structure Rules
+
+- Treat `src/` as the runtime root: UI lives in `src/components`, `src/pages`, and `src/layouts`, while shared logic sits in `src/lib`, `src/config`, and `src/utils` (`AGENTS.md`).
+- Server handlers are Astro API routes inside `src/pages/api/**`; R2 proxy routes reside in `src/pages/r2/**` and must stay ungated by middleware (`AGENTS.md`, `src/middleware.ts`).
+- Persist content under `src/content/` and locales in `src/locales/`; styles belong in `src/styles/` (per `AGENTS.md`).
+- Automation scripts and migrations continue under `scripts/` and `migrations/` (`AGENTS.md`).
+- Keep Playwright suites in both legacy `tests/e2e` and `test-suite-v2`; Vitest specs sit beside sources (`src/**/*.{test,spec}`) and under `tests/unit`, `tests/integration` (`vitest.config.ts`).
+- Built assets go to `dist/` (worker output) and static files to `public/`; Wrangler serves `dist` with `.assetsignore` excluding `_worker.js` (`package.json` `build:worker`, `wrangler.toml`).

--- a/.windsurf/rules/testing-and-ci.md
+++ b/.windsurf/rules/testing-and-ci.md
@@ -1,0 +1,8 @@
+# Testing & CI Rules
+
+- Run `npm run test` (Vitest) locally before PRs; it loads plugins `@vitejs/plugin-react` and `vite-tsconfig-paths` (`vitest.config.ts`).
+- Respect coverage gates: global thresholds 70% for statements/branches/functions/lines with `include: src/**/*.{ts,tsx}` and V8 provider (`vitest.config.ts`).
+- Place unit specs alongside sources (`src/**/*.{test,spec}`) or under `tests/unit`, and integration specs under `tests/integration` with `tests/integration/setup/global-setup.ts` for bootstrapping (`vitest.config.ts`).
+- Use `npm run test:e2e` for Playwright; config starts `npm run dev:e2e` automatically for local runs, injects same-origin `Origin` header, retries twice on CI, and stores HTML report in `playwright-report` (`playwright.config.ts`, `package.json`).
+- Keep Playwright device coverage across chromium/firefox/webkit; mobile variants are toggled via scripts like `test:e2e:mobile` (`package.json`).
+- Execute formatting/linting via `npm run format`, `format:check`, and `lint` (caps warnings at 280) prior to merging (`package.json`).

--- a/.windsurf/rules/tooling-and-style.md
+++ b/.windsurf/rules/tooling-and-style.md
@@ -1,0 +1,8 @@
+# Tooling & Style Rules
+
+- Use the strict TypeScript configuration from `tsconfig.json`: ESNext modules, React JSX runtime, and aliases like `@/*`, `@api/*`, `@components/*`.
+- Respect compiler gates `strict`, `noUnusedLocals`, `noUnusedParameters`, and `preserveSymlinks`; the project compiles in bundler resolution mode (`tsconfig.json`).
+- Follow ESLint policies from `eslint.config.js`: forbid `~/*` imports, warn on `any` and `_`-prefixed unused vars only, allow intentional empty `catch`, and enforce React hook rules.
+- Honor the targeted `no-console` rollout for specific API files listed at the bottom of `eslint.config.js`; do not expand without deliberate config changes.
+- Format code via Prettier (`.prettierrc.json`) with 2-space indent, single quotes, 100 char width, Astro plugin, and `semi: true`.
+- Keep components and stores in PascalCase filenames and shared utilities camelCase as codified in `AGENTS.md`.

--- a/cascade-rules-lint.txt
+++ b/cascade-rules-lint.txt
@@ -1,0 +1,1 @@
+Run `npm run lint` (caps warnings at 280 per `package.json`) and `npm run format:check` before shipping the Windsurf ruleset. Vitest coverage remains enforced at 70% thresholds via `vitest.config.ts`; e2e smoke can be triggered with `npm run test:e2e` if the Worker dev server is available.

--- a/docs/_generated/cascade-rules-detection.md
+++ b/docs/_generated/cascade-rules-detection.md
@@ -1,0 +1,31 @@
+# Cascade Rules Detection Summary
+
+## Source Signals Reviewed
+- `AGENTS.md` — repository guidelines outlining structure, naming, and workflow specifics.
+- `package.json` — scripts for development, testing, linting, and build automation plus dependency stack (Astro, Cloudflare adapter, Vitest, Playwright).
+- `tsconfig.json` — strict compiler configuration and path aliases.
+- `eslint.config.js` and `.prettierrc.json` — lint/format baselines.
+- `astro.config.mjs` — adapter mode, static asset headers, CSP defaults, and alias mapping.
+- `wrangler.toml` — environment bindings for D1, R2, KV, and production routing.
+- `vitest.config.ts` — unit/integration project setup and coverage thresholds.
+- `playwright.config.ts` — e2e bootstrap command, retry strategy, and headers.
+- `src/middleware.ts` — request logging, Basic Auth gate, locale handling, CSP nonce emission, and `/r2-ai/**` exclusions.
+- `src/lib/api-middleware.ts`, `src/lib/rate-limiter.ts`, `src/lib/security/csrf.ts` — API response contracts, security headers, rate limits, and CSRF utilities.
+- `src/config/coming-soon.ts` — overlay patterns, exclusions, and ENV overrides.
+
+## Verified Findings
+- Astro 5 with Cloudflare directory adapter handles server output while `build:worker` copies assets into `dist/assets` and writes `.assetsignore` (`astro.config.mjs`, `package.json`).
+- Development flows center on Wrangler-backed scripts (`dev:worker`, `dev:worker:dev`, `dev:e2e`) and Astro preview/build commands (`package.json`).
+- TypeScript operates in strict mode with bundler resolution, React JSX runtime, and alias coverage for `@/*` namespaces (`tsconfig.json`).
+- ESLint enforces React hook best practices, restricts `~/*` imports, and stages `no-console` enforcement for specific API files; Prettier sets 2-space, single-quote formatting with Astro plugin support (`eslint.config.js`, `.prettierrc.json`).
+- Vitest multi-project config runs unit tests in `jsdom` with `src/setupTests.ts`, integration tests in Node with global setup, and enforces 70% V8 coverage across statements/branches/lines/functions (`vitest.config.ts`).
+- Playwright injects an `Origin` header, spawns `npm run dev:e2e` when targeting localhost, and records HTML reports by default (`playwright.config.ts`).
+- Middleware safeguards include apex redirect, Basic Auth gating that skips `/api/**`, assets, and `/r2-ai/**`, CSP nonce creation, session cookie handling, and locale redirects (`src/middleware.ts`).
+- API middleware standardizes JSON payloads, sets security headers (HSTS preload, X-Frame-Options DENY, Permissions-Policy camera/microphone/geolocation empty), enforces same-origin, and supports CSRF double submit plus named rate limiter presets (30/min default, 10/min auth, 5/hour sensitive, etc.) (`src/lib/api-middleware.ts`, `src/lib/rate-limiter.ts`).
+- CSRF helpers mint 32-hex tokens with Lax cookies and validate header/cookie matches (`src/lib/security/csrf.ts`).
+- Coming Soon overlay protects `/datenschutz*` and honors env override `COMING_SOON` while applying default patterns to `/docs`, `/kontakt`, `/agb`, `/impressum` (`src/config/coming-soon.ts`).
+
+## Output Artifacts
+- Generated `.windsurf/global_rules.md` capturing the consolidated ruleset above.
+- Authored `.windsurf/rules/project-structure.md`, `tooling-and-style.md`, `api-and-security.md`, and `testing-and-ci.md` with evidence-backed constraints.
+- Logged lint guidance in `cascade-rules-lint.txt` (see repository root).


### PR DESCRIPTION
## Summary
- add evidence-backed Windsurf global rules and scoped rule docs
- record detection sources under docs/_generated/cascade-rules-detection.md
- note lint expectations in cascade-rules-lint.txt

## Testing
- not run (docs only)
