### PR TITLE
fix(debug-panel): respect dev env in local worker; test: name Vitest projects and update integration scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,17 @@ und dieser Projekt haftet an [Semantic Versioning](https://semver.org/spec/v2.0.
 - docs(frontend/imag-enhancer-ui-upgrade): Hinweis ergänzt, dass TEST_BASE_URL den laufenden Dev-Port widerspiegeln muss
 - docs(development/ci-cd): Abschnitt „Geplant: Enhancer E2E Smoke (EN+DE)“ mit Lauf- und Artefaktdetails ergänzt
 - Imag‑Enhancer: Tastatur‑Hinweis (i18n) erweitert – Pfeile/Shift+Pfeile, Home/End, 0, +/−, 1, L, Space (Hold)
+- dev(worker): Lokale Worker-Entwicklung nutzt jetzt `build:worker:dev` (Astro `--mode development`), damit `.env.development` greift und das Debug Panel aktiv ist (siehe `docs/tools/debug-panel.md`).
+- test(vitest): Projekte in `vitest.config.ts` benannt (`unit`, `integration`) und `package.json`-Skripte angepasst, sodass `--project=integration` zuverlässig funktioniert.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- debug-panel: In Dev war das Panel deaktiviert, da vorher ein Prod-Build `.env.production` erzwang (`PUBLIC_ENABLE_DEBUG_PANEL=false`). Dev-Build-Skript korrigiert.
+- tests/integration: Startfehler „No projects matched the filter \"integration\"“ behoben durch korrektes Setzen von `projects[].test.name`.
 
 ### Security
 


### PR DESCRIPTION
## Summary
- Use development mode build so `.env.development` is honored and Debug Panel and `/api/debug/logs-stream` work in dev.
- Name Vitest projects `unit` and `integration` in `vitest.config.ts` and align `package.json` scripts so `--project=integration` works.

## Root Cause
- Local worker built in production mode applied `.env.production` with `PUBLIC_ENABLE_DEBUG_PANEL=false`, disabling Debug Panel and `/api/debug/logs-stream`.
- Vitest project filter failed because project name was not placed where Vitest expects it.

## Changes
- `vitest.config.ts`: set projects `test.name` to `unit` and `integration`.
- `package.json`: update integration scripts to use `vitest.config.ts` with `--project=integration`.

## Testing
- Integration test passed: `tests/integration/api/debug-logs-stream.test.ts` (2 tests).
- Verified GET and POST to `/api/debug/logs-stream` work in dev.

## Checklist
- Dev mode build applies `.env.development`.
- Debug Panel visible; interceptors active.
- Integration tests green.
- Lint, format, type check OK.

## Related Docs
- `docs/tools/debug-panel.md`
