### PR TITLE
chore: public readiness (license, security, coc, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,11 @@
+---
+name: Bug report
+about: Help us improve by reporting a bug
+labels: bug
+---
+
+**Describe the bug**
+**Steps to reproduce**
+**Expected behavior**
+**Environment (browser/OS)**
+**Logs / Screenshots**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Problem / Use case**
+**Proposed solution**
+**Alternatives considered**
+**Additional context**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change? -->
+
+## Checklist
+
+- [ ] No workflows or automation added
+- [ ] No secrets or credentials included
+- [ ] Docs/README updated if needed
+
+## Related
+
+<!-- Closes #123, etc. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes apply to `main` and the latest stable release.
+
+## Reporting a Vulnerability
+
+Please email security@hub-evolution.com. Do **not** open public issues for vulnerabilities.
+We aim to acknowledge within 48 hours and resolve within 14–30 days depending on severity.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Reports: community@hub-evolution.com

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HubEvolution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds LICENSE (MIT), SECURITY policy, Code of Conduct, issue/PR templates.
No workflows, no dependabot, no automation. 
Prepares repository for safe public visibility and contributions.


------
https://chatgpt.com/codex/tasks/task_e_68eabafa7230832ba2e7f9067810f536