### PR TITLE
chore: move products.csv to docs/ops/billing

### DIFF
--- a/docs/ops/billing/products.csv
+++ b/docs/ops/billing/products.csv
@@ -1,0 +1,9 @@
+id,Name,Date (UTC),Description,Url,Tax Code
+prod_TH7w0dMQi82iqu,AI Credits 1500,2025-10-21 07:08,1500 AI image credits (one-time),,
+prod_TH7wuqSRMcq3Mh,AI Credits 500,2025-10-21 07:08,500 AI image credits (one-time),,
+prod_TH7wS0aR2kqt1c,AI Credits 100,2025-10-21 07:08,100 AI image credits (one-time),,
+prod_TH7wIHDfsszgBG,AI Enterprise Plan (Annual),2025-10-21 07:08,Enterprise plan annual billing (10× monthly),,
+prod_TH7wuNnw9Gsroe,AI Premium Plan (Annual),2025-10-21 07:08,Premium plan annual billing (10× monthly),,
+prod_TH7weHZsBzLgY6,AI Pro Plan (Annual),2025-10-21 07:08,Pro plan annual billing (10× monthly),,
+prod_T3TKEm9adoFSiz,Evolution Hub Premium,2025-09-14 20:18,,,
+prod_T3TKTCH9gsYJxD,Evolution Hub Pro,2025-09-14 20:18,,,

--- a/products.csv
+++ b/products.csv
@@ -1,9 +1,0 @@
-id,Name,Date (UTC),Description,Url,Tax Code
-prod_TH7w0dMQi82iqu,AI Credits 1500,2025-10-21 07:08,1500 AI image credits (one-time),,
-prod_TH7wuqSRMcq3Mh,AI Credits 500,2025-10-21 07:08,500 AI image credits (one-time),,
-prod_TH7wS0aR2kqt1c,AI Credits 100,2025-10-21 07:08,100 AI image credits (one-time),,
-prod_TH7wIHDfsszgBG,AI Enterprise Plan (Annual),2025-10-21 07:08,Enterprise plan annual billing (10× monthly),,
-prod_TH7wuNnw9Gsroe,AI Premium Plan (Annual),2025-10-21 07:08,Premium plan annual billing (10× monthly),,
-prod_TH7weHZsBzLgY6,AI Pro Plan (Annual),2025-10-21 07:08,Pro plan annual billing (10× monthly),,
-prod_T3TKEm9adoFSiz,Evolution Hub Premium,2025-09-14 20:18,,,
-prod_T3TKTCH9gsYJxD,Evolution Hub Pro,2025-09-14 20:18,,,


### PR DESCRIPTION
Verschiebt den Stripe-Produkt-Export `products.csv` aus dem Repo-Root nach `docs/ops/billing/products.csv`, damit er als Ops-/Billing-Artefakt erhalten bleibt, aber nicht wie ein versehentliches Root-Export wirkt.

- Added: `docs/ops/billing/products.csv`
- Removed: `products.csv` (Root)
